### PR TITLE
Gary: simplify slow ram select, revert register mirror decoding

### DIFF
--- a/rtl/minimig/gary.v
+++ b/rtl/minimig/gary.v
@@ -92,7 +92,6 @@ module gary
 );
 
 wire	[2:0] t_sel_slow;
-wire	sel_xram;
 wire	sel_bank_1; 				// $200000-$3FFFFF
 
 //--------------------------------------------------------------------------------------
@@ -139,27 +138,21 @@ begin
 		sel_chip[1] = cpu_address_in[23:19]==5'b0000_1 ? 1'b1 : 1'b0;
 		sel_chip[2] = cpu_address_in[23:19]==5'b0001_0 ? 1'b1 : 1'b0;
 		sel_chip[3] = cpu_address_in[23:19]==5'b0001_1 ? 1'b1 : 1'b0;
-		// AMR - filter out sel_slow signals based on memcfg
-		sel_slow[0] = sel_xram & t_sel_slow[0];
-		sel_slow[1] = sel_xram & t_sel_slow[1];
-		sel_slow[2] = sel_xram & t_sel_slow[2];
+		sel_slow[0] = t_sel_slow[0];
+		sel_slow[1] = t_sel_slow[1];
+		sel_slow[2] = t_sel_slow[2];
 		sel_kick    = (cpu_address_in[23:19]==5'b1111_1 && (cpu_rd || cpu_hlt)) || (cpu_rd && ovl && cpu_address_in[23:19]==5'b0000_0) ? 1'b1 : 1'b0; //$F80000 - $FFFFFF
 		sel_kickext = (cpu_address_in[23:19]==5'b1111_0 && (cpu_rd || cpu_hlt)) ? 1'b1 : 1'b0; //$F00000 - $F7FFFF
 		sel_kick1mb = (cpu_address_in[23:19]==5'b1110_0 && (cpu_rd || cpu_hlt)) ? 1'b1 : 1'b0; //$E00000 - $E7FFFF
 	end
 end
 
-assign t_sel_slow[0] = cpu_address_in[23:19]==5'b1100_0 ? 1'b1 : 1'b0; //$C00000 - $C7FFFF
-assign t_sel_slow[1] = cpu_address_in[23:19]==5'b1100_1 ? 1'b1 : 1'b0; //$C80000 - $CFFFFF
-assign t_sel_slow[2] = cpu_address_in[23:19]==5'b1101_0 ? 1'b1 : 1'b0; //$D00000 - $D7FFFF
+assign t_sel_slow[0] = |memory_config[3:2] && cpu_address_in[23:19]==5'b1100_0; //$C00000 - $C7FFFF
+assign t_sel_slow[1] =  memory_config[3]   && cpu_address_in[23:19]==5'b1100_1; //$C80000 - $CFFFFF
+assign t_sel_slow[2] = &memory_config[3:2] && cpu_address_in[23:19]==5'b1101_0; //$D00000 - $D7FFFF
 
 // 512kb extra rom area at $e0 and $f0 write able only at a1k chipset mode
 //assign t_sel_slow[2] = (cpu_address_in[23:19]==5'b1110_0 || cpu_address_in[23:19]==5'b1111_0) && (a1k | cpu_rd) ? 1'b1 : 1'b0; //$E00000 - $E7FFFF & $F00000 - $F7FFFF
-
-assign sel_xram = ((t_sel_slow[0] & (memory_config[2] | memory_config[3]))
-        | (t_sel_slow[1] & memory_config[3])
-        | (t_sel_slow[2] & memory_config[2] & memory_config[3]));
-
 
 assign sel_ide = hdc_ena && cpu_address_in[23:16]==8'b1101_1010 ? 1'b1 : 1'b0;		//IDE registers at $DA0000 - $DAFFFF	
 
@@ -167,9 +160,7 @@ assign sel_gayle = hdc_ena && cpu_address_in[23:12]==12'b1101_1110_0001 ? 1'b1 :
 
 assign sel_rtc = (cpu_address_in[23:16]==8'b1101_1100) ? 1'b1 : 1'b0;   //RTC registers at $DC0000 - $DCFFFF
 
-// AMR - decode 5 bits here to avoid unmapped C80000 / D00000 accesses going to hardware registers.
-// Matching D8xxxx - DFxxxx
-assign sel_reg = cpu_address_in[23:19]==5'b11011 ? ~(sel_xram | sel_rtc | sel_ide | sel_gayle) : 1'b0;		//chip registers at $DF0000 - $DFFFFF
+assign sel_reg = cpu_address_in[23:21]==3'b110 ? ~(|t_sel_slow | sel_rtc | sel_ide | sel_gayle) : 1'b0;		//chip registers at $DF0000 - $DFFFFF
 
 assign sel_cia = cpu_address_in[23:20]==4'b1011 ? 1'b1 : 1'b0;
 


### PR DESCRIPTION
Reverted the register decoding, also simplified slow ram decoding according to this:
https://github.com/mist-devel/minimig-mist/commit/19a38b7e21d2d616daabf488163a4ffd164917d6