### PR TITLE
output wire cannot have default set, changed into reg.

### DIFF
--- a/rtl/minimig/amber.v
+++ b/rtl/minimig/amber.v
@@ -82,7 +82,7 @@ module amber
   output reg            _hsync_out=0,   // horizontal synchronisation out
   output reg            _vsync_out=0,   // vertical synchronisation out
   output reg				_csync_out=0,
-  output wire            selcsync=0,
+  output reg            selcsync=0,
   output wire				osd_blank_out,
   output wire				osd_pixel_out
 );


### PR DESCRIPTION
Hi, 

Vivado won't compile without this change.

Kind regards, Paul 