### PR TITLE
wire selcsync can not have a default value

### DIFF
--- a/rtl/minimig/amber.v
+++ b/rtl/minimig/amber.v
@@ -82,7 +82,7 @@ module amber
   output reg            _hsync_out=0,   // horizontal synchronisation out
   output reg            _vsync_out=0,   // vertical synchronisation out
   output reg				_csync_out=0,
-  output reg            selcsync=0,
+  output wire            selcsync,
   output wire				osd_blank_out,
   output wire				osd_pixel_out
 );

--- a/rtl/minimig/amber.v
+++ b/rtl/minimig/amber.v
@@ -82,7 +82,7 @@ module amber
   output reg            _hsync_out=0,   // horizontal synchronisation out
   output reg            _vsync_out=0,   // vertical synchronisation out
   output reg				_csync_out=0,
-  output wire            selcsync=0,
+  output reg            selcsync=0,
   output wire				osd_blank_out,
   output wire				osd_pixel_out
 );

--- a/rtl/sdram/cpu_cache_new.v
+++ b/rtl/sdram/cpu_cache_new.v
@@ -103,8 +103,8 @@ wire [ 3-1:0] cpu_adr_blk;
 wire [ 8-1:0] cpu_adr_idx;
 wire [14-1:0] cpu_adr_tag;
 // cache line cache
-reg   [8-1:0] cpu_cacheline_lo[8];
-reg   [8-1:0] cpu_cacheline_hi[8];
+reg   [8-1:0] cpu_cacheline_lo[0:7];
+reg   [8-1:0] cpu_cacheline_hi[0:7];
 reg  [26-1:4] cpu_cacheline_adr;
 wire          cpu_cacheline_valid;
 reg           cpu_cacheline_dirty;

--- a/rtl/soc/TG68K.vhd
+++ b/rtl/soc/TG68K.vhd
@@ -325,7 +325,7 @@ sel_eth<='0';
   -- 32bit address space for 68020, limit address space to 24bit for 68000/68010
   cpuaddr <= addrtg68 WHEN cpu(1) = '1' ELSE X"00" & addrtg68(23 downto 0);
 
-pf68K_Kernel_inst: work.TG68KdotC_Kernel
+pf68K_Kernel_inst: entity work.TG68KdotC_Kernel
   generic map (
     SR_Read         => 2, -- 0=>user,   1=>privileged,    2=>switchable with CPU(0)
     VBR_Stackframe  => 2, -- 0=>no,     1=>yes/extended,  2=>switchable with CPU(0)

--- a/rtl/virtual/hybrid_pwm_sd.v
+++ b/rtl/virtual/hybrid_pwm_sd.v
@@ -70,6 +70,7 @@ wire terminated = terminate & term_ena;
 reg [13:0] initctr = 14'h3e00;
 wire init = initctr[13];
 reg [13:0] initctr_l = 14'h3e00;
+reg dump;
 
 always @(posedge clk) begin
 	if(init && dump) begin
@@ -88,7 +89,6 @@ end
 // Periodic dumping of the accumulator to kill standing tones.
 // Yes, I know, yuck.  In practice it works better than would be expected.
 reg [7:0] dumpcounter;
-reg dump;
 
 always @(posedge clk) begin
 	dump <=1'b0;


### PR DESCRIPTION
Hi, 

Vivado won't compile without this change.

Kind regards, Paul 